### PR TITLE
Fix: accurate `sigma_eff_m` calculation for small w / large Vmax

### DIFF
--- a/sashimi_si.py
+++ b/sashimi_si.py
@@ -362,7 +362,7 @@ class SIDM_cross_section(units_and_constants):
             (Default is 703., based on that Ei(-a) returns NaN for such large a.)
         degree : int, optional
             The degree of the polynomial expansion used for large a.
-            (Default is 5, which gives a good approximation for large a.)
+            (Default is 6, which gives a good approximation for large a.)
         Returns
         -------
         sigma_eff : float or np.ndarray

--- a/sashimi_si.py
+++ b/sashimi_si.py
@@ -417,7 +417,7 @@ class SIDM_parametric_model(SIDM_cross_section):
         sigma_eff_m : float
             The effective cross section of SIDM divided by m.
         """
-        return self.sigma_eff_analytical(self, self.sigma0_m, self.w, Vmax)
+        return self.sigma_eff_analytical(self.sigma0_m, self.w, Vmax)
 
 
     def t_collapse(self, sigma_eff_m, rmax, Vmax):


### PR DESCRIPTION
This pull request introduces a new analytical method for calculating the effective cross section of SIDM (Self-Interacting Dark Matter) divided by mass, alongside replacing the existing numerical quadrature method with the new analytical approach in the initialization of the `SIDM_parametric_model` class.

### Key changes:

#### Addition of an analytical method:
* Added a new method `sigma_eff_m_interpolate_analytical` in `sashimi_si.py` to compute the effective cross section of SIDM divided by mass using an analytical formula. It includes handling for large values of the parameter `a` using a polynomial expansion, and interpolation for effective velocity dispersion (`[sashimi_si.pyR334-R388](diffhunk://#diff-0881744802a80e49edc9fcbf94c0768a3425bd8d6cea423e5f2c3736af373308R334-R388)`).

#### Replacement of numerical interpolation:
* Updated the `__init__` method of the `SIDM_parametric_model` class to use the new `sigma_eff_m_interpolate_analytical` method instead of the previous `sigma_eff_m_interpolate` method for initializing `self.sigma_eff_m` (`[sashimi_si.pyL358-R413](diffhunk://#diff-0881744802a80e49edc9fcbf94c0768a3425bd8d6cea423e5f2c3736af373308L358-R413)`).